### PR TITLE
[WEB-USER,COMMON][ADD]: 마이페이지 고객센터 화면 추가

### DIFF
--- a/.claude/skills/picake-review-ios-app-store/SKILL.md
+++ b/.claude/skills/picake-review-ios-app-store/SKILL.md
@@ -64,9 +64,28 @@ Picake web-user는 겉면만 Flutter로 감싼 **웹뷰 앱**입니다 — 로�
 
 **3차 반려(2026-08-17, 별개 사유 — 인증 코드 요구)**: 이번엔 "제공한 데모 계정 아이디/비밀번호만으로는 부족하고, 콘텐츠 접근·기능 검증을 위한 **인증 코드**가 추가로 필요하다"는 지적으로, 위 활성 지역 버그와는 다른 사유임(원문은 `.claude/exchange.md` 참고). Apple은 통화로 코드를 받거나, 데모 계정이 코드 검증을 건너뛰게 하거나, 고정 코드를 Review Notes에 적어달라고 제안함. 대응은 §2의 심사용 로그인(코드는 이미 고정값)을 안내하는 것으로 충분해 보이나, **이 반려가 왜 발생했는지(심사관이 §2의 탭-10회 진입법을 못 찾았는지, 아니면 구글 로그인 자체에서 2단계 인증을 요구했는지)는 확인되지 않음** — 재발 방지를 위해 심사노트(§3)에 §2의 로그인 방법을 반드시 명시하고, 구글 데모 계정(`picakeee@gmail.com`)도 함께 제공해 Apple에 재확인 요청함. Apple 응답이 오면 실제 원인을 여기 갱신할 것.
 
+**4차 반려(2026-08-18 리뷰, Submission ID `ce18c36d-a87a-48d5-b722-60c43c98a365`, 빌드 1.0.0 (16)) — 이번엔 명확히 "Sign in with Apple 과정"으로 한정**: 메일 원문: "in addition to the demo account username and password you provided, we need an authentication code to complete the **Sign in with Apple** process." 3차와 달리 이번엔 범용 문구가 아니라 Apple 로그인 플로우로 특정됨. Apple이 제시한 3가지 해결책 중 우리 구조와 가장 맞는 건 **"a demonstration mode that exhibits the app's full features and functionality"** — 이건 이미 만들어둔 §2 심사용 로그인(REVIEW_ACCOUNT 바이패스) 그 자체다. 유력한 원인: 심사관이 Apple 로그인 버튼을 직접 눌러 iOS 네이티브 Apple ID 로그인 시트로 진입했고, 거기서 Apple 자체 2단계 인증 코드(우리가 절대 줄 수 없는, 신뢰할 수 있는 기기로 전송되는 코드)를 요구받은 것으로 추정 — 이건 우리 앱/백엔드 코드로 우회할 수 없는 Apple 계정 자체의 보안 절차다. **코드를 고치는 문제가 아니라 App Store Connect 제출 정보(Review Notes / App Review Information의 Sign-In Required 데모 계정 필드)의 문제일 가능성이 높음**:
+- App Review Information에 등록된 데모 계정이 실제 Apple ID(2FA 걸린 개인 계정)인지 앱담당자에게 확인 — 그렇다면 그 계정으로 로그인을 시도하게 유도한 것 자체가 원인이므로 삭제/교체 대상.
+- 재제출 시 Review Notes 맨 앞에 "Sign in with Apple/Google 등 소셜 로그인을 시도할 필요 없이, 아래 데모 모드로 모든 기능을 확인할 수 있습니다"를 §3 템플릿보다 더 명시적으로 못박을 것 — §3 초안은 이미 순서상 1번으로 데모 로그인을 안내하고 있으니, **문구 자체보다 "이번 제출에 이 노트가 실제로 붙여넣어졌는지"부터 의심**(§4 절차 2번).
+- 코드로 할 수 있는 일은 없음 — REVIEW_LOGIN_CODE 최신값 재확인(§2)과 Review Notes 재점검/재제출이 전부.
+
 ### 2.1 App Completeness — 로그인 없이 둘러보기 가능한지 확인 완료
 
 홈/상품/스토어 상세는 로그인 없이 열람 가능 (`useRequireLogin`은 주문 상세(`useOrderDetail.ts`) 등 사용자 전용 데이터에만 적용, 홈 목록/검색/지도에는 없음). 심사관이 로그인 없이 앱을 처음 켰을 때 빈 화면이나 강제 로그인 벽을 만나지 않는지 실제로 확인하세요.
+
+### 1.5 Safety — Support URL이 실제 지원 페이지로 연결되지 않음 — 신규, 미해결
+
+**반려 내용(2026-08-18)**: "The Support URL provided in App Store Connect, http://picakes.com, does not direct to a website with information users can use to ask questions and request support." → Support URL을 실제 지원 정보가 있는 페이지로 바꾸라는 요구.
+
+**확인된 사실**: `http://picakes.com`은 App Store Connect의 "Support URL" 메타데이터 필드 값이며(이 필드 자체는 네이티브 앱 담당자가 App Store Connect에서 직접 관리 — §0), 도메인 루트는 web-user 앱의 홈 화면(상품/스토어 목록)이 그대로 뜬다 — 별도 마케팅 랜딩 페이지가 없는 구조라서 지원/문의 페이지로는 전혀 기능하지 않는다. 저장소 전체를 확인했을 때 "고객센터"·"문의"·연락처(이메일/전화)를 로그인 없이 볼 수 있는 페이지가 **하나도 없다**:
+- `/mypage/qna` (`apps/web-user/src/app/mypage/qna/page.tsx`) — 로그인 없이 접근 가능(백엔드 `/v1/consumer/qnas`가 `@Auth({ isPublic: true })`)하고 관리자가 등록한 FAQ 아코디언을 보여주긴 하지만, 연락처나 "질문하기" 수단이 이 화면 자체엔 없음.
+- `/mypage/terms/terms-of-service` 등 약관 페이지는 DB에 저장된 콘텐츠([[picake-legal-terms]] skill §1 — 상호/대표자/고객센터 이메일 `picakeee@gmail.com`/전화 `010-3007-5647` 포함)를 렌더링하지만, 법적 고지문 안에 묻혀 있어 Apple이 원하는 "지원 페이지"로 보기엔 부적합.
+
+**해결 방향(둘 다 필요, 아직 미착수)**:
+1. **App Store Connect 메타데이터** — Support URL 필드를 실제 지원 페이지 경로로 교체 (예: `https://picakes.com/mypage/qna` 또는 아래 2번으로 만들 전용 지원 페이지). 이건 앱담당자가 App Store Connect에서 직접 수정해야 함, 이 저장소로 할 수 없음.
+2. **web-user 코드** — 로그인 없이 접근 가능한 전용 지원 페이지(가칭 `/support`)를 만들어 고객센터 이메일(`picakeee@gmail.com`)·전화(`010-3007-5647`)를 눈에 띄게 노출하고, 필요하면 기존 `/mypage/qna` FAQ를 그 안에 링크하는 걸 권장 — `/mypage/qna` 하나만 Support URL로 지정해도 통과될 순 있지만 "ask questions" 요건(질문할 수 있는 연락 수단)이 약해서 재반려 리스크가 있음.
+
+**진행 전 사용자 확인 필요**: 연락처 값을 픽션으로 지어내지 않는다(§0 원칙과 동일) — 위 이메일/전화는 [[picake-legal-terms]] skill 표에 있는 기존 확인값을 그대로 재사용한 것이며, 최신값인지 재확인 후 페이지를 만들 것.
 
 ### 3.1.1 / 3.1.5 인앱결제 — 구조상 해당 없음, 오해 방지용으로 심사노트에 명시 권장
 
@@ -153,3 +172,5 @@ If you have any questions, please contact us at picakeee@gmail.com.
 - [ ] `curl https://picakes.com/.well-known/apple-app-site-association`가 `{ applinks: { details: [] } }`인지(Universal Links 비활성 유지) 확인
 - [ ] App Store Connect의 App Privacy 설문이 [[picake-legal-terms]] skill의 개인정보처리방침(수집 항목)과 일치하는지 앱담당자에게 확인 요청
 - [ ] §3 심사노트에 최신 코드 값·연락처를 채워 App Store Connect에 실제로 붙여넣기
+- [ ] App Review Information의 Sign-In Required 데모 계정이 개인 Apple ID(2FA 있음)가 아닌지 확인 — Sign in with Apple을 직접 시도하게 유도하는 값이면 제거/교체 (§1의 2.1(a) 4차 반려 항목 참고)
+- [ ] App Store Connect의 Support URL이 실제 지원/문의 정보가 있는 페이지를 가리키는지 확인 (§1의 1.5 항목 참고 — 현재 `http://picakes.com`은 앱 홈 화면일 뿐이라 미해결)

--- a/apps/web-user/src/app/mypage/page.tsx
+++ b/apps/web-user/src/app/mypage/page.tsx
@@ -204,6 +204,7 @@ export default function MypagePage() {
         {[
           { label: "공지사항", href: PATHS.NOTICE },
           { label: "Q&A", href: PATHS.QNA },
+          { label: "고객센터", href: PATHS.SUPPORT },
         ].map(({ label, href }) => (
           <LinkListItem key={label} href={href} label={label} />
         ))}

--- a/apps/web-user/src/app/mypage/support/page.tsx
+++ b/apps/web-user/src/app/mypage/support/page.tsx
@@ -1,0 +1,11 @@
+import Header from "@/apps/web-user/common/components/headers/Header";
+import { CustomerSupportScreen } from "@/apps/web-user/features/mypage/components/CustomerSupportScreen";
+
+export default function SupportPage() {
+  return (
+    <div>
+      <Header variant="back-title" title="고객센터" />
+      <CustomerSupportScreen />
+    </div>
+  );
+}

--- a/apps/web-user/src/common/constants/paths.constant.ts
+++ b/apps/web-user/src/common/constants/paths.constant.ts
@@ -50,6 +50,7 @@ export const PATHS = {
   RECENT: "/mypage/recent",
   NOTICE: "/mypage/notice",
   QNA: "/mypage/qna",
+  SUPPORT: "/mypage/support",
   SETTING: "/mypage/setting",
   SETTING_ACCOUNT: "/mypage/setting/account",
   SETTING_NOTIFICATION: "/mypage/setting/notification",

--- a/apps/web-user/src/features/mypage/components/CustomerSupportScreen.tsx
+++ b/apps/web-user/src/features/mypage/components/CustomerSupportScreen.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Image from "next/image";
+import type { ReactNode } from "react";
+import { Icon } from "@/apps/web-user/common/components/icons";
+
+const SUPPORT_EMAIL = "picakeee@gmail.com";
+const SUPPORT_PHONE = "010-3007-5647";
+const KAKAO_CHANNEL_NAME = "픽케이크";
+const INSTAGRAM_HANDLE = "picake_app";
+
+function MailIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className="text-gray-900"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5" width="18" height="14" rx="2" stroke="currentColor" strokeWidth="1.6" />
+      <path
+        d="M4 7l8 6 8-6"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+interface SupportRowProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  /** 생략 시 탭할 수 없는 단순 정보 표시 행(아이디/채널명 안내용) */
+  onClick?: () => void;
+}
+
+function SupportRow({ icon, label, value, onClick }: SupportRowProps) {
+  const content = (
+    <>
+      <div className="w-6 h-6 shrink-0 flex items-center justify-center">{icon}</div>
+      <div className="flex-1 text-left">
+        <p className="text-sm font-bold text-gray-900">{label}</p>
+        <p className="text-xs text-gray-500 mt-0.5">{value}</p>
+      </div>
+      {onClick && (
+        <Icon name="arrow" width={20} height={20} className="text-gray-900 rotate-90 shrink-0" />
+      )}
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className="w-full flex items-center gap-3 px-5 py-4 border-b border-gray-100">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-3 px-5 py-4 border-b border-gray-100"
+    >
+      {content}
+    </button>
+  );
+}
+
+/**
+ * 마이페이지 > 고객센터.
+ * 로그인 없이도 접근 가능해야 함 — App Store 심사(가이드라인 1.5)의 Support URL이 이 화면을 가리킴.
+ */
+export function CustomerSupportScreen() {
+  return (
+    <div className="pt-4 pb-10">
+      <SupportRow
+        icon={<MailIcon />}
+        label="이메일"
+        value={SUPPORT_EMAIL}
+        onClick={() => {
+          window.location.href = `mailto:${SUPPORT_EMAIL}`;
+        }}
+      />
+      <SupportRow
+        icon={
+          <Image
+            src="/images/contents/talk_phone.png"
+            alt="전화 문의"
+            width={24}
+            height={24}
+            className="w-6 h-6 rounded-full object-cover"
+          />
+        }
+        label="전화 문의"
+        value={SUPPORT_PHONE}
+        onClick={() => {
+          window.location.href = `tel:${SUPPORT_PHONE.replace(/[^0-9+]/g, "")}`;
+        }}
+      />
+      <SupportRow
+        icon={
+          <Image
+            src="/images/contents/talk_kakao.png"
+            alt="카카오톡 채널"
+            width={24}
+            height={24}
+            className="w-6 h-6 rounded-full object-cover"
+          />
+        }
+        label="카카오톡 채널"
+        value={KAKAO_CHANNEL_NAME}
+      />
+      <SupportRow
+        icon={
+          <Image
+            src="/images/contents/talk_insta.png"
+            alt="인스타그램"
+            width={24}
+            height={24}
+            className="w-6 h-6 rounded-full object-cover"
+          />
+        }
+        label="인스타그램"
+        value={`@${INSTAGRAM_HANDLE}`}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 요약

App Store 심사 반려(가이드라인 1.5, Support URL)에 대응해 마이페이지에 고객센터 화면을 추가합니다. 이메일/전화/카카오톡 채널/인스타그램 연락처를 로그인 없이 확인할 수 있습니다.

## ✨ 주요 변경사항

- [WEB-USER] 마이페이지 > 고객 서비스 섹션에 "고객센터" 메뉴 추가 (`/mypage/support`, 로그인 없이 접근 가능)
- [WEB-USER] 이메일(`picakeee@gmail.com`)·전화(`010-3007-5647`)는 탭 시 `mailto:`/`tel:`로 연결, 카카오톡 채널("픽케이크")·인스타그램(`@picake_app`)은 아이디만 안내하는 정보 행으로 구성
- [COMMON] iOS 심사 대응 skill 문서에 4차 반려(2.1a, Sign in with Apple 인증 코드 요구)와 신규 1.5(Support URL) 반려 이력 반영

## 🧪 테스트 계획

- [ ] staging에서 `/mypage/support`가 로그인 없이 정상 노출되는지 확인
- [ ] 이메일/전화 행 탭 시 각각 메일 앱/전화 앱으로 정상 연결되는지 확인
- [ ] App Store Connect의 Support URL을 `https://picakes.com/mypage/support`로 교체 (앱담당자 작업, 이 PR 범위 밖)

## 📎 참고 사항

- 카카오톡 채널 URL은 실제 값을 확인하지 못해 클릭 불가능한 텍스트 정보로만 넣었습니다. 필요 시 이후 PR에서 실제 채널 URL로 교체 가능합니다.
- Apple 로그인 관련 4차 반려(2.1a)는 코드 수정이 아니라 App Store Connect의 Review Notes/데모 계정 재확인이 필요한 사안이라 이 PR에는 코드 변경이 없습니다 — skill 문서에만 기록했습니다.
